### PR TITLE
Create custom command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Jorge Gonzalez Albisu
+Copyright (c) 2025 @jgonzalezalbisu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 A custom Cypress command to handle interactions of elements within an iframe
 
+## Description
+
+`cy-enter-iframe` is a Cypress custom command that simplifies working with iframes in your end to end tests. This plugin provides a reliable way to access and interact with elements inside iframes by returning the iframe's body as a chainable Cypress command.
+
+The command handles common iframe challenges such as:
+- Waiting for iframe content to load
+- Ensuring iframe visibility
+- Accessing the iframe's document content
+- Providing a chainable interface for seamless testing
+

--- a/README.md
+++ b/README.md
@@ -12,3 +12,123 @@ The command handles common iframe challenges such as:
 - Accessing the iframe's document content
 - Providing a chainable interface for seamless testing
 
+## Installation
+
+Install the package as a development dependency:
+
+```bash
+npm install cy-enter-iframe -D
+```
+
+Then import or require it in your `cypress/support/e2e.js` file:
+
+```javascript
+// ES6 import
+import 'cy-enter-iframe';
+
+// or CommonJS require
+require('cy-enter-iframe');
+```
+
+## Correct Usage
+
+The `enterIframeBody` command should always be used with Cypress's `.within()` command to interact with elements inside the iframe.
+
+### Example 1: Basic iframe interaction
+
+```javascript
+cy.enterIframeBody('iframe').within(() => {
+  cy.get('#button-inside-iframe').click();
+  cy.get('#input-field').type('Hello World');
+});
+```
+
+### Example 2: Multiple actions within iframe
+
+```javascript
+cy.enterIframeBody('#payment-iframe').within(() => {
+  cy.get('[data-cy="card-number"]').type('4111111111111111');
+  cy.get('[data-cy="expiry"]').type('12/25');
+  cy.get('[data-cy="cvv"]').type('123');
+  cy.get('[data-cy="submit-payment"]').click();
+});
+```
+
+### Example 3: Assertions within iframe
+
+```javascript
+cy.enterIframeBody('.content-frame').within(() => {
+  cy.get('h1').should('contain.text', 'Welcome');
+  cy.get('.status').should('have.class', 'active');
+  cy.get('ul li').should('have.length', 3);
+});
+```
+
+## Incorrect Usage
+
+Here are common mistakes to avoid when using this command:
+
+### ❌ Don't use without `.within()`
+
+```javascript
+// WRONG - This won't work as expected
+cy.enterIframeBody('iframe').get('#button'); // This will search in the main document, not iframe
+```
+
+### ❌ Don't chain other commands directly
+
+```javascript
+// WRONG - Direct chaining doesn't work
+cy.enterIframeBody('iframe').click(); // This tries to click the iframe body itself
+```
+
+### ❌ Don't use with multiple iframes without specific selectors
+
+```javascript
+// WRONG - Ambiguous when multiple iframes exist
+cy.enterIframeBody('iframe').within(() => { // Uses .last() but may not be the intended iframe
+  cy.get('#button').click();
+});
+
+// CORRECT - Use specific selectors
+cy.enterIframeBody('#specific-iframe').within(() => {
+  cy.get('#button').click();
+});
+```
+
+### ❌ Don't forget to wait for iframe content
+
+```javascript
+// WRONG - Not waiting for iframe to load content
+cy.visit('/page-with-iframe');
+cy.enterIframeBody('iframe').within(() => {
+  cy.get('#dynamic-content').click(); // May fail if content isn't loaded yet
+});
+
+// CORRECT - The command handles this, but you may need additional waits for dynamic content
+cy.visit('/page-with-iframe');
+cy.enterIframeBody('iframe').within(() => {
+  cy.get('#dynamic-content').should('be.visible').click();
+});
+```
+
+## API
+
+### `cy.enterIframeBody(iFrameSelectorCSS)`
+
+**Parameters:**
+- `iFrameSelectorCSS` (string): CSS selector for the iframe element
+
+**Returns:**
+- Chainable Cypress command containing the iframe's body element
+
+**Note:** This command will only work when there is ONE iframe matching the selector on the page. If multiple iframes match, it will use the last one found.
+
+## Requirements
+
+- Cypress 10.0.0 or higher
+- Node.js 14.0.0 or higher
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # cy-enter-iframe
+
 A custom Cypress command to handle interactions of elements within an iframe
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "cy-enter-iframe",
+	"version": "1.0.0",
+	"description": "A custom Cypress command to handle interactions of elements within an iframe",
+	"main": "src/index.js",
+	"types": "src/index.d.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jgonzalezalbisu/cy-enter-iframe"
+	},
+	"keywords": [
+		"Cypress",
+		"iframe",
+		"Testing",
+		"Automation"
+	],
+	"author": "@jgonzalezalbisu (https://github.com/jgonzalezalbisu)",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/jgonzalezalbisu/cy-enter-iframe/issues"
+	},
+	"homepage": "https://github.com/jgonzalezalbisu/cy-enter-iframe#readme"
+}

--- a/package.json
+++ b/package.json
@@ -4,15 +4,25 @@
 	"description": "A custom Cypress command to handle interactions of elements within an iframe",
 	"main": "src/index.js",
 	"types": "src/index.d.ts",
+	"files": [
+		"src/"
+	],
+	"peerDependencies": {
+		"cypress": ">=10.0.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/jgonzalezalbisu/cy-enter-iframe"
 	},
 	"keywords": [
-		"Cypress",
+		"cypress",
 		"iframe",
-		"Testing",
-		"Automation"
+		"testing",
+		"automation",
+		"e2e",
+		"cypress-plugin",
+		"cypress-command",
+		"custom-command"
 	],
 	"author": "@jgonzalezalbisu (https://github.com/jgonzalezalbisu)",
 	"license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+	interface Chainable {
+		/**
+		 * This method returns the body of a single iframe that matches the given selector and checking the visibility of it.
+		 * It will only work when there is ONE iframe on the page.
+		 * The function is a Parent Cypress command, so it can be used in a test like this:
+		 * @param iFrameSelectorCSS The selector for the iframe you want to get the body of.
+		 * @example cy.enterIframeBody("iframe").within(($iFrameBody)=>{
+		 * cy.get("selector within the iframe").should("be.visible");
+		 * })
+		 * @returns The body of the iframe as a chainable Cypress command to keep interacting with elements within. This should be used with a `within(($iFrame)=>{...}) command to continue with the desired behaviors.
+		 */
+		enterIframeBody(iFrameSelectorCSS: string): Chainable<Subject>;
+	}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,3 @@
-/**
- * This method returns the body of a single iframe that matches the given selector and checking the visibility of it.
- * It will only work when there is ONE iframe on the page.
- * The function is a Parent Cypress command, so it can be used in a test like this:
- * @param {string} iFrameSelectorCSS - The selector for the iframe you want to get the body of.
- * @example cy.enterIframeBody("iframe").within(($iFrameBody)=>{
- * cy.get("selector within the iframe").should("be.visible");
- * })
- * @returns The body of the iframe as a chainable Cypress command to keep interacting with elements within. This should be used with a `within(($iFrame)=>{...}) command to continue with the desired behaviors.
- */
 Cypress.Commands.add("enterIframeBody", (iFrameSelectorCSS) => {
 	cy.log(`Entering iFrame ${iFrameSelectorCSS}`);
 	return cy

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,24 @@
+/**
+ * This method returns the body of a single iframe that matches the given selector and checking the visibility of it.
+ * It will only work when there is ONE iframe on the page.
+ * The function is a Parent Cypress command, so it can be used in a test like this:
+ * @param {string} iFrameSelectorCSS - The selector for the iframe you want to get the body of.
+ * @example cy.enterIframeBody("iframe").within(($iFrameBody)=>{
+ * cy.get("selector within the iframe").should("be.visible");
+ * })
+ * @returns The body of the iframe as a chainable Cypress command to keep interacting with elements within. This should be used with a `within(($iFrame)=>{...}) command to continue with the desired behaviors.
+ */
+Cypress.Commands.add("enterIframeBody", (iFrameSelectorCSS) => {
+	cy.log(`Entering iFrame ${iFrameSelectorCSS}`);
+	return cy
+		.get(iFrameSelectorCSS)
+		.last()
+		.should("exist")
+		.scrollIntoView()
+		.should("be.visible")
+		.its("0.contentDocument")
+		.should("exist")
+		.its("body")
+		.should("not.be.empty")
+		.then(cy.wrap);
+});


### PR DESCRIPTION
This pull request introduces a new Cypress custom command, `cy-enter-iframe`, to simplify interactions with iframes during end-to-end testing. It includes updates to the documentation, licensing, and package metadata, along with the implementation of the command itself.

### New Feature: `cy-enter-iframe` Command
* Added a custom Cypress command `enterIframeBody` in `src/index.js` to streamline iframe interactions by handling visibility, scrolling, and content loading.

### Documentation Updates
* Expanded the `README.md` with detailed usage instructions, examples, common mistakes to avoid, API documentation, and requirements for the `cy-enter-iframe` command.

### Package Metadata
* Created a `package.json` file for the `cy-enter-iframe` package, specifying metadata such as name, version, description, dependencies, and repository details.

### Licensing
* Updated the `LICENSE` file to replace the author's name with their GitHub handle, `@jgonzalezalbisu`.